### PR TITLE
Use sync Google Analytics template to support v3 and v4

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -5,7 +5,7 @@
 </div>
 
 {{ if not .Site.IsServer }}
-{{ template "_internal/google_analytics_async.html" . }}
+{{ template "_internal/google_analytics.html" . }}
 {{ end }}
 {{- with .Site.Params.Social -}}
 <script>feather.replace()</script>


### PR DESCRIPTION
Per https://gohugo.io/templates/internal/#google-analytics, only the sync template supports both v3 and v4. The template recognizes UA or G prefix and generates the code for v3 or v4 respectively.